### PR TITLE
Reverting use toolchain from #11. Update bazel-contrib/setup-bazel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@e8776f58fb6a6e9055cbaf1b38c52ccc5247e9c4 # ratchet:bazel-contrib/setup-bazel@0.14.0
+        uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8 # ratchet:bazel-contrib/setup-bazel@0.15.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ matrix.os }}
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@e8776f58fb6a6e9055cbaf1b38c52ccc5247e9c4 # ratchet:bazel-contrib/setup-bazel@0.14.0
+        uses: bazel-contrib/setup-bazel@4fd964a13a440a8aeb0be47350db2fc640f19ca8 # ratchet:bazel-contrib/setup-bazel@0.15.0
         with:
           bazelisk-cache: true
           disk-cache: ${{ matrix.os }}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -28,7 +28,6 @@ rust.toolchain(
     edition = "2024",
     versions = ["1.86.0"],
 )
-use_repo(rust, "rust_toolchains")
 
 # Rust crates
 crate = use_extension("@rules_rust//crate_universe:extension.bzl", "crate")


### PR DESCRIPTION
Continued work on getting proper build incantation for fat binaries on Apple platforms. The `use_repo` change from #11 is no lonegr necessary with build changes in Santa.